### PR TITLE
添加配方冲突检查工具

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,8 +111,8 @@ dependencies {
     implementation(include("io.github.llamalad7:mixinextras-forge:$project.mixinextras_version"))
 
     // lombok
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     modImplementation 'appeng:appliedenergistics2-forge-15.2.1'
 

--- a/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2AbilityHelper.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2AbilityHelper.java
@@ -1,0 +1,97 @@
+package org.gtlcore.gtlcore.api.item.tool.ae2.patternTool;
+
+import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.content.Content;
+import net.minecraft.world.item.ItemStack;
+import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+public class Ae2AbilityHelper {
+   final GTRecipe recipe;
+
+    protected Ae2AbilityHelper(GTRecipe recipe) {
+        this.recipe = recipe;
+    }
+
+    public List<ItemStack> getInputItemStacks(){
+        return getInputItemStacksFromRecipe(recipe);
+    }
+    public List<FluidStack> getInputFluidStacks(){
+        return getInputFluidStacksFromRecipe(recipe);
+    }
+
+    public List<ItemStack> getOutputItemStacks(){
+        return getOutputItemStacksFromRecipe(recipe);
+    }
+    public List<FluidStack> getOutputFluidStacks(){
+        return getOutputFluidStacksFromRecipe(recipe);
+    }
+
+    public static List<ItemStack> getInputItemStacksFromRecipe(GTRecipe recipe) {
+        if (recipe == null) {
+            return Collections.emptyList();
+        }
+        return recipe.getInputContents(ItemRecipeCapability.CAP).stream()
+                .map(getContentItemStackFunction())
+                .toList();
+    }
+    public static List<FluidStack> getInputFluidStacksFromRecipe(GTRecipe recipe) {
+        if (recipe == null) {
+            return Collections.emptyList();
+        }
+        return recipe.getInputContents(FluidRecipeCapability.CAP).stream()
+                .map(getContentFluidStackFunction())
+                .toList();
+    }
+    public static List<ItemStack> getOutputItemStacksFromRecipe(GTRecipe recipe) {
+        if (recipe == null) {
+            return Collections.emptyList();
+        }
+        return recipe.getOutputContents(ItemRecipeCapability.CAP).stream()
+                .map(getContentItemStackFunction())
+                .toList();
+    }
+    public static List<FluidStack> getOutputFluidStacksFromRecipe(GTRecipe recipe) {
+        if (recipe == null) {
+            return Collections.emptyList();
+        }
+        return recipe.getOutputContents(FluidRecipeCapability.CAP).stream()
+                .map(getContentFluidStackFunction())
+                .toList();
+    }
+
+
+    public static String getItemTranslatedName(ItemStack itemStack) {
+        return itemStack.getItem().getName(itemStack).getString();
+    }
+    public static String getFluidTranslatedName(FluidStack fluidStack) {
+        return fluidStack.getDisplayName().getString();
+    }
+
+
+    private static @NotNull Function<Content, FluidStack> getContentFluidStackFunction() {
+        return content -> {
+            if (content == null || content.getContent() == null) {
+                return FluidStack.empty();
+            }
+            FluidStack[] stacks = FluidRecipeCapability.CAP.of(content.getContent()).getStacks();
+            return (stacks != null && stacks.length > 0) ? stacks[0] : FluidStack.empty();
+        };
+    }
+    private static @NotNull Function<Content, ItemStack> getContentItemStackFunction() {
+        return content -> {
+            if (content == null || content.getContent() == null) {
+                return ItemStack.EMPTY;
+            }
+            ItemStack stack = ItemRecipeCapability.CAP.of(content.getContent()).kjs$getFirst();
+            return (stack != null) ? stack : ItemStack.EMPTY;
+        };
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2Pattern.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2Pattern.java
@@ -1,0 +1,135 @@
+package org.gtlcore.gtlcore.api.item.tool.ae2.patternTool;
+
+import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.content.Content;
+import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.item.IntCircuitBehaviour;
+import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
+import lombok.Data;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.*;
+
+
+public class Ae2Pattern {
+    public GTRecipe recipe;
+
+    public List<ItemStack> inputItemStacks = new ArrayList<>();
+    public List<FluidStack> inputFluidStacks = new ArrayList<>();
+    public List<ItemStack> outputItemStacks = new ArrayList<>();
+    public List<FluidStack> outputFluidStacks = new ArrayList<>();
+
+    public List<String> inputItemIds = new ArrayList<>();
+    public List<String> inputFluidIds = new ArrayList<>();
+    public List<String> outputItemIds = new ArrayList<>();
+    public List<String> outputFluidIds = new ArrayList<>();
+
+    public Map<String,Long> inputItemIdsMap = new HashMap<>();
+    public Map<String,Long> inputFluidIdsMap = new HashMap<>();
+    public Map<String,Long> outputItemIdsMap = new HashMap<>();
+    public Map<String,Long> outputFluidIdsMap = new HashMap<>();
+
+    public Number CIRCUIT;
+
+    public List<String> ignoreItems = new ArrayList<>(List.of(
+            "programmed_circuit" // 方便处理，后续所有白名单匹配都使用ID
+    ));
+    public List<String> ignoreFluids = new ArrayList<>(List.of());
+    private boolean hasINTEGRATED_CIRCUIT=false;
+
+
+    public Ae2Pattern(GTRecipe recipe) {
+        this.recipe = recipe;
+        this.populateItemStacks(recipe.getInputContents(ItemRecipeCapability.CAP),inputItemStacks,inputItemIds,inputItemIdsMap);
+        this.populateFluidStacks(recipe.getInputContents(FluidRecipeCapability.CAP),inputFluidStacks,inputFluidIds,inputFluidIdsMap);
+        this.populateItemStacks(recipe.getOutputContents(ItemRecipeCapability.CAP),outputItemStacks,outputItemIds,outputItemIdsMap);
+        this.populateFluidStacks(recipe.getOutputContents(FluidRecipeCapability.CAP),outputFluidStacks,outputFluidIds,outputFluidIdsMap);
+    }
+
+    private void populateItemStacks(List<Content> contentList,
+                                    List<ItemStack> stackList,
+                                    List<String> itemIdList,
+                                    Map<String,Long> itemIdsMap) {
+        contentList.forEach(content -> {
+            ItemStack itemStack = ItemRecipeCapability.CAP.of(content.getContent()).kjs$getFirst();
+            if (itemStack.getItem().equals((GTItems.INTEGRATED_CIRCUIT.asItem()))) {
+                this.CIRCUIT= IntCircuitBehaviour.getCircuitConfiguration(itemStack);
+                hasINTEGRATED_CIRCUIT=true;
+                return; // 不将电路编入ids
+            }
+            stackList.add(itemStack);
+            itemIdList.add(itemStack.kjs$getId());
+            itemIdsMap.put(itemStack.kjs$getId(), (long) itemStack.getCount());
+        });
+        if(!hasINTEGRATED_CIRCUIT) {
+            this.CIRCUIT=0;
+        }
+    }
+
+    private void populateFluidStacks(List<Content> contentList,
+                                     List<FluidStack> stackList,
+                                     List<String> fluidIdList,
+                                     Map<String,Long> FluidIdsMap) {
+        contentList.forEach(content -> {
+            FluidStack[] fluidStackList = FluidRecipeCapability.CAP.of(content.getContent()).getStacks();
+
+            FluidStack fluidStack = fluidStackList.length > 0 ? fluidStackList[0] : FluidStack.empty();
+            stackList.add(fluidStack);
+            if(!fluidStack.isEmpty()){
+                String key = Objects.requireNonNull(ForgeRegistries.FLUIDS.getKey(fluidStack.getFluid())).toString();
+                fluidIdList.add(key);
+                FluidIdsMap.put(key,fluidStack.getAmount());
+            }
+        });
+    }
+
+    private void initializeProgrammedCircuit(List<ItemStack> inputItemStacks) {
+
+    }
+
+    public String toString(){
+        return ("""
+                // ---------- start ---------- //
+                CIRCUIT: %S
+                inputs:
+                List<ItemStack>: %s
+                List<FluidStack> : %s
+                inputItemIds : %s
+                inputFluidIds : %s
+                inputItemIdsMap : %s
+                inputFluidIdsMap : %s
+                outputs:
+                List<ItemStack>: %s
+                List<FluidStack> : %s
+                outputItemIds : %s
+                outputFluidIds : %s
+                outputItemIdsMap : %s
+                outputFluidIdsMap : %s
+                // ---------- stopA ---------- //
+                """.formatted(
+                        this.CIRCUIT,
+                        inputItemStacks,
+                inputFluidStacks,
+
+                inputItemIds,
+                inputFluidIds,
+
+                inputItemIdsMap,
+                inputFluidIdsMap,
+
+                outputItemStacks,
+                outputFluidStacks,
+
+                outputItemIds,
+                outputFluidIds,
+
+                outputItemIdsMap,
+                outputFluidIdsMap
+        ));
+    };
+
+
+}

--- a/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2PatternConflict.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2PatternConflict.java
@@ -1,0 +1,39 @@
+package org.gtlcore.gtlcore.api.item.tool.ae2.patternTool;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class Ae2PatternConflict {
+    boolean conflict;
+    List<String> matchPool;
+    List<String> storagePool;
+    Ae2Pattern ae2Pattern;
+
+
+    public Ae2PatternConflict(boolean conflict, List<String> matchPool, List<String> storagePool, Ae2Pattern ae2Pattern) {
+        this.conflict = conflict; // 程序不出错的情况下一定为true，仅供检验用
+        this.matchPool = matchPool; // 冲突配方的材料池，包含物品和流体
+        this.storagePool = storagePool; // 同电路同机器类型的所有配方的材料池，包含物品和流体
+        this.ae2Pattern = ae2Pattern; // 冲突配方的对象，可以通过这个获取原recipe
+    }
+
+    public void exportToPrint(){
+        System.out.printf("// Type : %s --------- CIRCUIT : %s //%n", ae2Pattern.recipe.getType(), ae2Pattern.CIRCUIT);
+        System.out.println(">>材料:");
+        Ae2AbilityHelper.getInputItemStacksFromRecipe(ae2Pattern.recipe).forEach(itemStack -> {
+            System.out.println("材料:"+ Ae2AbilityHelper.getItemTranslatedName(itemStack));
+        });
+        Ae2AbilityHelper.getInputFluidStacksFromRecipe(ae2Pattern.recipe).forEach(fluidStack -> {
+            System.out.println("材料:"+ Ae2AbilityHelper.getFluidTranslatedName(fluidStack));
+        });
+        System.out.println(">>成品:");
+        Ae2AbilityHelper.getOutputItemStacksFromRecipe(ae2Pattern.recipe).forEach(itemStack -> {
+            System.out.println("物品:"+ Ae2AbilityHelper.getItemTranslatedName(itemStack));
+        });
+        Ae2AbilityHelper.getOutputFluidStacksFromRecipe(ae2Pattern.recipe).forEach(fluidStack -> {
+            System.out.println("流体:"+ Ae2AbilityHelper.getFluidTranslatedName(fluidStack));
+        });
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2PatternManager.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2PatternManager.java
@@ -1,0 +1,66 @@
+package org.gtlcore.gtlcore.api.item.tool.ae2.patternTool;
+
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+public class Ae2PatternManager {
+    ////////////////////////////////////////////////
+    //  使用配方recipe自动生成的样板对象(工具类)的集
+    //  一个Manager所管理的配方是一个机器的类型所能制造的配方
+    ////////////////////////////////////////////////
+    public List<Ae2Pattern> ae2Patterns;
+
+    public Ae2PatternManager(List<GTRecipe> recipes) {
+        this.ae2Patterns = new ArrayList<Ae2Pattern>();
+        recipes.forEach(recipe -> ae2Patterns.add(new Ae2Pattern(recipe)));
+    }
+
+    public Ae2PatternManager(List<Ae2Pattern> ae2Patterns, boolean dummy) {
+        this.ae2Patterns = ae2Patterns;
+    }
+
+    public static Ae2PatternConflict findConflict(Ae2Pattern ae2Pattern, List<Ae2Pattern> ae2Patterns){
+        boolean conflict_k_14223 = false;
+        ae2Patterns = ae2Patterns.stream().filter(ae2Pattern1 -> !ae2Pattern1.equals(ae2Pattern)).toList();
+        List<String> matchPool= Stream.of(ae2Pattern.inputFluidIds, ae2Pattern.inputItemIds).flatMap(Collection::stream).toList();
+        List<String> storagePool=new ArrayList<>();
+        ae2Patterns
+                .forEach(ae2Pattern1 -> {
+                    storagePool.addAll(ae2Pattern1.inputFluidIds);
+                    storagePool.addAll(ae2Pattern1.inputItemIds);
+                });
+        if(new HashSet<>(storagePool).containsAll(matchPool)){
+            conflict_k_14223=true;
+        }
+        return new Ae2PatternConflict(conflict_k_14223,matchPool,storagePool,ae2Pattern);
+
+
+
+    }
+
+    public List<Ae2PatternConflict> useFindConflictForAll(Number circuit){
+        //initialize
+        List<Ae2PatternConflict> ae2PatternConflictList = new ArrayList<>();
+
+        //preprocessData
+        List<Ae2Pattern> ae2PatternList = this.ae2Patterns.stream()
+                .filter(ae2Pattern -> (Objects.equals(ae2Pattern.CIRCUIT, circuit) || ae2Pattern.CIRCUIT.equals(0))) // 任何电路的机器都可以运行0号电路
+                .toList();
+
+        //useConflictProcessLogic
+        ae2PatternList.forEach(ae2Pattern -> {
+            Ae2PatternConflict ae2PatternConflict = findConflict(ae2Pattern, ae2PatternList);
+            if(ae2PatternConflict.conflict){
+                ae2PatternConflictList.add(ae2PatternConflict);
+            }
+        });
+
+        return ae2PatternConflictList;
+    }
+
+    public void printAllObject(){
+        this.ae2Patterns.forEach(ae2Pattern -> System.out.println(ae2Pattern.toString()));
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/common/data/GTLItems.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/data/GTLItems.java
@@ -24,6 +24,7 @@ import com.gregtechceu.gtceu.common.item.TooltipBehavior;
 import com.tterrag.registrate.util.entry.ItemEntry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
+import org.gtlcore.gtlcore.common.item.PatternTestBehavior;
 import org.gtlcore.gtlcore.common.item.StructureWriteBehavior;
 import org.gtlcore.gtlcore.utils.TextUtil;
 
@@ -196,6 +197,12 @@ public class GTLItems {
             .item("debug_structure_writer", ComponentItem::create)
             .onRegister(GTItems.attach(StructureWriteBehavior.INSTANCE))
             .register();
+
+    public static final ItemEntry<ComponentItem> DEBUG_PATTERN_TEST = REGISTRATE
+            .item("debug_pattern_test", ComponentItem::create)
+            .onRegister(GTItems.attach(PatternTestBehavior.INSTANCE))
+            .register();
+
 
     public static final ItemEntry<StorageComponentItem> CELL_COMPONENT_1M = registerStorageComponentItem(1);
     public static final ItemEntry<StorageComponentItem> CELL_COMPONENT_4M = registerStorageComponentItem(4);

--- a/src/main/java/org/gtlcore/gtlcore/common/item/PatternTestBehavior.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/item/PatternTestBehavior.java
@@ -89,6 +89,7 @@ public class PatternTestBehavior implements IItemUIFactory {
         // 序列化返回结果
         ae2PatternConflicts.forEach(Ae2PatternConflict::exportToPrint);
         System.out.printf("可能冲突配方数量%s / 所有此电路配方数%s%n", ae2PatternConflicts.toArray().length,recipes.toArray().length);
+
     }
 
     @Override

--- a/src/main/java/org/gtlcore/gtlcore/common/item/PatternTestBehavior.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/item/PatternTestBehavior.java
@@ -1,0 +1,111 @@
+package org.gtlcore.gtlcore.common.item;
+
+import com.gregtechceu.gtceu.api.gui.GuiTextures;
+import com.gregtechceu.gtceu.api.item.component.IItemUIFactory;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
+import com.lowdragmc.lowdraglib.gui.factory.HeldItemUIFactory;
+import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
+import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
+import com.lowdragmc.lowdraglib.gui.texture.TextTexture;
+import com.lowdragmc.lowdraglib.gui.widget.ButtonWidget;
+import com.lowdragmc.lowdraglib.gui.widget.ImageWidget;
+import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
+import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.server.ServerLifecycleHooks;
+import org.gtlcore.gtlcore.api.item.tool.ae2.patternTool.Ae2PatternConflict;
+import org.gtlcore.gtlcore.api.item.tool.ae2.patternTool.Ae2PatternManager;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class PatternTestBehavior implements IItemUIFactory {
+    public static final PatternTestBehavior INSTANCE = new PatternTestBehavior();
+
+    protected PatternTestBehavior() {
+        /**/
+    }
+
+    @Override
+    public ModularUI createUI(HeldItemUIFactory.HeldItemHolder heldItemHolder, Player player) {
+        var containerPatternAnalysis=new WidgetGroup(8,8,160,50)
+                .addWidget(new ImageWidget(4,4,152,42,GuiTextures.DISPLAY))
+                .addWidget(new LabelWidget(8,8,"AE样板冲突分析"))
+                .addWidget(new ButtonWidget(
+                        8,8+9+4,64,24,
+                        new GuiTextureGroup(
+                                GuiTextures.BUTTON,
+                                new TextTexture("开始分析组装机")),
+                                clickData -> analysisRecipesBaby(heldItemHolder))
+                );
+
+        var containerPatternGeneratoe=new WidgetGroup(8,58,160,50)
+                .addWidget(new ImageWidget(4,4,152,42,GuiTextures.DISPLAY))
+                .addWidget(new LabelWidget(7,7,"AE样板生成器 没开始做"));
+
+
+        return new ModularUI(176,8+50+8+50+8,heldItemHolder,player)
+                .widget(containerPatternAnalysis)
+                .widget(containerPatternGeneratoe)
+                .background(GuiTextures.BACKGROUND)
+                ;
+    }
+
+    public void analysisRecipesBaby(HeldItemUIFactory.HeldItemHolder playerInventoryHolder){
+        if (playerInventoryHolder.getPlayer() instanceof ServerPlayer serverPlayer) {
+            analysisRecipesBaby(GTRecipeTypes.ASSEMBLER_RECIPES,0);
+        }
+    }
+
+    public void analysisRecipesBaby(GTRecipeType recipeType, int CIRCUIT){
+        // 筛选出化学反应釜的配方
+        MinecraftServer currentServer = ServerLifecycleHooks.getCurrentServer();
+        RecipeManager recipeManager = currentServer.getRecipeManager();
+        Set<GTRecipe> recipes=new HashSet<>();
+        for(Recipe<?> recipe : recipeManager.getRecipes()){
+            if(recipe instanceof GTRecipe && recipe.getType().equals(recipeType)){
+                recipes.add((GTRecipe) recipe);
+            }
+        }
+        // 构造输入，调用类，对电路为0的配方分析
+        Ae2PatternManager ae2PatternManager =new Ae2PatternManager(recipes.stream().toList());
+        List<Ae2PatternConflict> ae2PatternConflicts = ae2PatternManager.useFindConflictForAll(CIRCUIT);
+
+        // 序列化返回结果
+        ae2PatternConflicts.forEach(Ae2PatternConflict::exportToPrint);
+        System.out.printf("可能冲突配方数量%s / 所有此电路配方数%s%n", ae2PatternConflicts.toArray().length,recipes.toArray().length);
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Item item, Level level, Player player, InteractionHand usedHand) {
+        ItemStack stack = player.getItemInHand(usedHand);
+        if(player instanceof ServerPlayer serverPlayer) {
+            HeldItemUIFactory.INSTANCE.openUI(serverPlayer, usedHand);
+        }
+        return new InteractionResultHolder<>(InteractionResult.SUCCESS, stack);
+    }
+
+    @Override
+    public InteractionResult useOn(UseOnContext context) {
+        ItemStack stack = context.getItemInHand();
+        if(context.getPlayer() instanceof ServerPlayer serverPlayer) {
+            serverPlayer.displayClientMessage(Component.literal("右键空气打开GUI"),true);
+        }
+        return InteractionResult.SUCCESS;
+    }
+}

--- a/src/main/java/org/gtlcore/gtlcore/common/item/PatternTestBehavior.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/item/PatternTestBehavior.java
@@ -51,7 +51,7 @@ public class PatternTestBehavior implements IItemUIFactory {
                         new GuiTextureGroup(
                                 GuiTextures.BUTTON,
                                 new TextTexture("开始分析组装机")),
-                                clickData -> analysisRecipesBaby(heldItemHolder))
+                                clickData -> useAnalysisRecipesBaby(heldItemHolder))
                 );
 
         var containerPatternGeneratoe=new WidgetGroup(8,58,160,50)
@@ -66,7 +66,7 @@ public class PatternTestBehavior implements IItemUIFactory {
                 ;
     }
 
-    public void analysisRecipesBaby(HeldItemUIFactory.HeldItemHolder playerInventoryHolder){
+    public void useAnalysisRecipesBaby(HeldItemUIFactory.HeldItemHolder playerInventoryHolder){
         if (playerInventoryHolder.getPlayer() instanceof ServerPlayer serverPlayer) {
             analysisRecipesBaby(GTRecipeTypes.ASSEMBLER_RECIPES,0);
         }


### PR DESCRIPTION
/give @a gtlcore:debug_pattern_test
有个按钮，点一下就会在idea控制台输出配方信息

物品behavior在org/gtlcore/gtlcore/common/item/PatternTestBehavior.java
物品用到的工具类创建在org/gtlcore/gtlcore/api/item/tool/ae2/patternTool包里面

检测逻辑：假设要检测的电路是3
先提取出所有此类型配方，然后提取电路是0和3的所有配方
然后从配方池循环抽取配方，如果这个配方的材料是其他配方材料的子集，那么认为其他材料可能做出这个配方=>串了

存在的问题：
1.调用比较麻烦
![image](https://github.com/user-attachments/assets/7598e331-f2ad-4d6b-a85f-7c48b88a3449)
要在PatternTestBehavior.java改这里
因为我还不会写带输入框的GUI

2.像是组装机那样的，所有橡胶都是0号电路的，冲突较多
不过我觉得确实应该一种橡胶一个电路，毕竟流体窜物品不窜，物品，电路和橡胶绑定的话，也能减少很多橡胶卡机器的事发生

3.样板自动生成功能还没有写，不过后面会写，可以在任务解锁或提交一定大额数量的物品解锁这个功能，这样配方就可以肆意妄为的加螺丝之类的加大难度，还不用被骂啦