### PR TITLE
大改，为样板修改器增加样板输入最大物品和流体限制，可以分别设置。样板输出不受限制影响

### DIFF
--- a/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2BaseProcessingPattern.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2BaseProcessingPattern.java
@@ -8,7 +8,6 @@ import com.tterrag.registrate.util.entry.ItemEntry;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 import org.gtlcore.gtlcore.GTLCore;
 
 import java.util.ArrayList;
@@ -45,7 +44,7 @@ public class Ae2BaseProcessingPattern {
     }
 
 
-    public void useSetScale(int newScale,boolean div,long maxStack) {
+    public void useSetScale(int newScale,boolean div,long maxItemStack,long maxFluidStack) {
         try{
             ItemStack oldPatternStack = this.patternStack;
             ItemStack newPatternStack;
@@ -54,7 +53,8 @@ public class Ae2BaseProcessingPattern {
                     newScale,
                     div,
                     Objects.requireNonNull(Ae2BaseProcessingPatternHelper.decodeToAEProcessingPattern(oldPatternStack, serverPlayer)),
-                    maxStack
+                    maxItemStack,
+                    maxFluidStack
             );
             if (newPatternStack != null && !newPatternStack.isEmpty()) {
                 this.patternStack = newPatternStack;
@@ -64,13 +64,15 @@ public class Ae2BaseProcessingPattern {
         }
     }
 
-    public void setScale(int newScale,boolean div,long maxStack) {
-        maxStack=Math.min(maxStack,1000000L);
-        useSetScale(newScale, div, maxStack);
+    public void setScale(int newScale,boolean div,long maxItemStack,long maxFluidStack) {
+        maxFluidStack=Math.min(maxFluidStack,1000000L);
+        maxItemStack=Math.min(maxItemStack,1000000L);
+        useSetScale(newScale, div, maxItemStack,maxFluidStack);
     }
     public void setScale(int newScale,boolean div) {
-        long maxStack=1000000L;
-        useSetScale(newScale, div, maxStack);
+        long maxItemStack=1000000L;
+        long maxFluidStack =1000000L;
+        useSetScale(newScale, div, maxItemStack,maxFluidStack);
     }
 
     public ItemStack getPatternItemStack(){

--- a/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2BaseProcessingPatternHelper.java
+++ b/src/main/java/org/gtlcore/gtlcore/api/item/tool/ae2/patternTool/Ae2BaseProcessingPatternHelper.java
@@ -2,6 +2,7 @@ package org.gtlcore.gtlcore.api.item.tool.ae2.patternTool;
 
 import appeng.api.crafting.PatternDetailsHelper;
 import appeng.api.stacks.AEItemKey;
+import appeng.api.stacks.AEKeyType;
 import appeng.api.stacks.GenericStack;
 import appeng.crafting.pattern.AEProcessingPattern;
 import appeng.crafting.pattern.EncodedPatternItem;
@@ -16,10 +17,10 @@ import java.util.List;
 
 public class Ae2BaseProcessingPatternHelper {
     // 乘或除 输入解码后样板，输出编码后样板
-    public static ItemStack multiplyScale(int scale, boolean div, AEProcessingPattern patternDetail,long maxStack){
+    public static ItemStack multiplyScale(int scale, boolean div, AEProcessingPattern patternDetail,long maxItemStack,long maxFluidStack){
         var input = patternDetail.getSparseInputs();
         var output = patternDetail.getOutputs();
-        if (checkModify(input, scale, div,maxStack) && checkModify(output, scale, div,maxStack)) {
+        if (checkModify(input, scale, div, maxItemStack,maxFluidStack) && checkModify(output, scale, div,10000000L,1000000L)) {
             var mulInput = new GenericStack[input.length];
             var mulOutput = new GenericStack[output.length];
             modifyStacks(input, mulInput, scale, div);
@@ -71,7 +72,7 @@ public class Ae2BaseProcessingPatternHelper {
         return false;
     }
 
-    private static boolean checkModify(GenericStack[] stacks, int scale, boolean div,long maxStack) {
+    private static boolean checkModify(GenericStack[] stacks, int scale, boolean div,long maxItemStack,long maxFluidStack) {
         if (div) {
             for (var stack : stacks) {
                 if (stack != null) {
@@ -83,9 +84,17 @@ public class Ae2BaseProcessingPatternHelper {
         } else {
             for (var stack : stacks) {
                 if (stack != null) {
-                    long upper = maxStack * stack.what().getAmountPerUnit();
-                    if (stack.amount() * scale > upper) {
-                        return false;
+                    if(stack.what().getType().equals(AEKeyType.fluids())){
+                        long upper = maxFluidStack * stack.what().getAmountPerUnit();
+                        if (stack.amount() * scale > upper) {
+                            return false;
+                        }
+                    }
+                    if(stack.what().getType().equals(AEKeyType.items())){
+                        long upper = maxItemStack * stack.what().getAmountPerUnit();
+                        if (stack.amount() * scale > upper) {
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/main/java/org/gtlcore/gtlcore/common/item/PatternModifier.java
+++ b/src/main/java/org/gtlcore/gtlcore/common/item/PatternModifier.java
@@ -35,7 +35,8 @@ import java.util.HashMap;
 public class PatternModifier implements IItemUIFactory {
     public static final PatternModifier INSTANCE = new PatternModifier();
     private int Ae2PatternGeneratorScale = 1;
-    private long Ae2PatternGeneratorMaxStack = 1000000L;
+    private long Ae2PatternGeneratorMaxItemStack = 1000000L;
+    private long Ae2PatternGeneratorMaxFluidStack = 1000000L;
     private int Ae2PatternGeneratorDivScale = 1;
 
     @Override
@@ -45,24 +46,32 @@ public class PatternModifier implements IItemUIFactory {
                         .addWidget(new ImageWidget(8,8,160,108, GuiTextures.DISPLAY))
                         .addWidget(new LabelWidget(12, 12, "AE样板倍乘器"))
                         .addWidget(new LabelWidget(12, 22, "设置倍数后，shift右键样板供应器方块使用"))
-                        .addWidget(new LabelWidget(12, 32, "先做乘法，后做除法"))
+                        .addWidget(new LabelWidget(12, 32, "先做乘法，后做除法，数量限制对成品不生效"))
                         .addWidget(new AETextInputButtonWidget(90, 40, 72, 12)
                                 .setText(String.valueOf(Ae2PatternGeneratorScale))
                                 .setOnConfirm(this::setAe2PatternGeneratorScale)
                                 .setButtonTooltips(Component.literal("设置模板乘数")))
                         .addWidget(new AETextInputButtonWidget(90, 54, 72, 12)
-                                .setText(String.valueOf(Ae2PatternGeneratorMaxStack))
-                                .setOnConfirm(this::setAe2PatternGeneratorMaxStack)
-                                .setButtonTooltips(Component.literal("设置乘法后最大物品或流体数量 个或B")))
-                        .addWidget(new AETextInputButtonWidget(90, 68, 72, 12)
                                 .setText(String.valueOf(Ae2PatternGeneratorDivScale))
                                 .setOnConfirm(this::setAe2PatternGeneratorDivScale)
                                 .setButtonTooltips(Component.literal("设置模板除数")))
+                        .addWidget(new AETextInputButtonWidget(90, 68, 72, 12)
+                                .setText(String.valueOf(Ae2PatternGeneratorMaxItemStack))
+                                .setOnConfirm(this::setAe2PatternGeneratorMaxItemStack)
+                                .setButtonTooltips(Component.literal("设置乘法后最大物品/个")))
+                        .addWidget(new AETextInputButtonWidget(90, 82, 72, 12)
+                                .setText(String.valueOf(Ae2PatternGeneratorMaxFluidStack))
+                                .setOnConfirm(this::setAe2PatternGeneratorMaxFluidStack)
+                                .setButtonTooltips(Component.literal("设置乘法后最大流体/桶")))
         ).background(GuiTextures.BACKGROUND);
     }
 
-    private void setAe2PatternGeneratorMaxStack(String s) {
-        Ae2PatternGeneratorMaxStack= Integer.parseInt(s);
+    private void setAe2PatternGeneratorMaxFluidStack(String s) {
+        Ae2PatternGeneratorMaxFluidStack = Integer.parseInt(s);
+    }
+
+    private void setAe2PatternGeneratorMaxItemStack(String s) {
+        Ae2PatternGeneratorMaxItemStack = Integer.parseInt(s);
     }
 
     private void setAe2PatternGeneratorDivScale(String s) {
@@ -125,10 +134,7 @@ public class PatternModifier implements IItemUIFactory {
                 while (i<soltNumber){
                     ItemStack itemStack = internalInventory.getStackInSlot(i);
                     if (!itemStack.isEmpty()) {
-                        Ae2BaseProcessingPattern ae2BaseProcessingPattern = new Ae2BaseProcessingPattern(itemStack, serverPlayer);
-                        ae2BaseProcessingPattern.setScale(Ae2PatternGeneratorScale,false,Ae2PatternGeneratorMaxStack);
-                        ae2BaseProcessingPattern.setScale(Ae2PatternGeneratorDivScale,true);
-                        ItemStack patternItemStack = ae2BaseProcessingPattern.getPatternItemStack();
+                        ItemStack patternItemStack = getNewPatternItemStack(serverPlayer, itemStack);
                         newItemStackHashMap.put(i, patternItemStack);
                     }
                     i++;
@@ -146,5 +152,15 @@ public class PatternModifier implements IItemUIFactory {
             }
         }
         return InteractionResult.SUCCESS;
+    }
+
+    private ItemStack getNewPatternItemStack(ServerPlayer serverPlayer, ItemStack itemStack) {
+        Ae2BaseProcessingPattern ae2BaseProcessingPattern = new Ae2BaseProcessingPattern(itemStack, serverPlayer);
+        ae2BaseProcessingPattern.setScale(Ae2PatternGeneratorScale,
+                false,
+                Ae2PatternGeneratorMaxItemStack,
+                Ae2PatternGeneratorMaxFluidStack);
+        ae2BaseProcessingPattern.setScale(Ae2PatternGeneratorDivScale,true);
+        return ae2BaseProcessingPattern.getPatternItemStack();
     }
 }


### PR DESCRIPTION
例如输入总成每个槽只有64B的大小，那就可以在里面设置64B后，无脑shift倍乘样板达到最大效率